### PR TITLE
Enable openshift-ansible installation to use a PR

### DIFF
--- a/reference-architecture/vmware-ansible/scripts/install_openshift_ansible.sh
+++ b/reference-architecture/vmware-ansible/scripts/install_openshift_ansible.sh
@@ -24,9 +24,9 @@ TAG=${TAG/refs\/tags\//}
 
 if [[ ! -d $TARGET_DIR ]]; then
     mkdir -p $TARGET_DIR
-    git clone $OPENSHIFT_ANSIBLE_GIT_URL --single-branch --branch $TAG $TARGET_DIR
-else
-    cd $TARGET_DIR
-    git fetch -t --all
-    git reset --hard $TAG
+    git clone --single-branch $OPENSHIFT_ANSIBLE_GIT_URL $TARGET_DIR
 fi
+
+cd $TARGET_DIR
+git fetch origin $TAG
+git reset --hard FETCH_HEAD


### PR DESCRIPTION
#### What does this PR do?
With this change, the 'tag' for openshift-ansible can point to a pull-request in GitHub. In order to download the changes for a PR, pass 'pull/${PR}/head' as the value for the 'tag'.

#### How should this be manually tested?

For example:

    $ ./install_openshift_ansible.sh /tmp/work pull/11068/head

#### Who would you like to review this?
cc: @vponomaryov  PTAL
